### PR TITLE
Launching the game from powershell prevents VS locking inside the build process

### DIFF
--- a/SpaceWarp.Template/templates/SpaceWarpMod/src/SpaceWarpMod/Directory.Build.targets
+++ b/SpaceWarp.Template/templates/SpaceWarpMod/src/SpaceWarpMod/Directory.Build.targets
@@ -52,6 +52,6 @@
               DestinationFolder="$(KSP2DIR)/BepInEx/plugins/$(ProjectName)/%(RecursiveDir)"/>
 
         <Message Text="Deploy plugin and run game" Condition="$(ConfigurationName) == DeployAndRun"/>
-        <Exec Command="&quot;$(KSP2DIR)/KSP2_x64.exe&quot;" Condition="$(ConfigurationName) == DeployAndRun"/>
+        <Exec Command="powershell &quot;start-process &quot;&quot;$(KSP2DIR)\KSP2_x64.exe&quot;&quot;&quot;" Condition="$(ConfigurationName) == DeployAndRun"/>
     </Target>
 </Project>

--- a/SpaceWarp.Template/templates/SpaceWarpModEmpty/src/SpaceWarpModEmpty/Directory.Build.targets
+++ b/SpaceWarp.Template/templates/SpaceWarpModEmpty/src/SpaceWarpModEmpty/Directory.Build.targets
@@ -52,6 +52,6 @@
               DestinationFolder="$(KSP2DIR)/BepInEx/plugins/$(ProjectName)/%(RecursiveDir)"/>
 
         <Message Text="Deploy plugin and run game" Condition="$(ConfigurationName) == DeployAndRun"/>
-        <Exec Command="&quot;$(KSP2DIR)/KSP2_x64.exe&quot;" Condition="$(ConfigurationName) == DeployAndRun"/>
+        <Exec Command="powershell &quot;start-process &quot;&quot;$(KSP2DIR)\KSP2_x64.exe&quot;&quot;&quot;" Condition="$(ConfigurationName) == DeployAndRun"/>
     </Target>
 </Project>

--- a/SpaceWarp.Template/templates/SpaceWarpModLibrary/src/SpaceWarpModLibrary/Directory.Build.targets
+++ b/SpaceWarp.Template/templates/SpaceWarpModLibrary/src/SpaceWarpModLibrary/Directory.Build.targets
@@ -56,6 +56,6 @@
               DestinationFolder="$(KSP2DIR)/BepInEx/plugins/$(ProjectName)/%(RecursiveDir)"/>
 
         <Message Text="Deploy plugin and run game" Condition="$(ConfigurationName) == DeployAndRun"/>
-        <Exec Command="&quot;$(KSP2DIR)/KSP2_x64.exe&quot;" Condition="$(ConfigurationName) == DeployAndRun"/>
+        <Exec Command="powershell &quot;start-process &quot;&quot;$(KSP2DIR)\KSP2_x64.exe&quot;&quot;&quot;" Condition="$(ConfigurationName) == DeployAndRun"/>
     </Target>
 </Project>


### PR DESCRIPTION
When using DeployAndRun configuration current template(s) lock VisualStudio in a build process until the game is terminated. This means you cannot do some things in VS while the game is running, like renaming classes/methods/variables.

See here: https://discord.com/channels/1078696971088433153/1078841771771056280/1139627723262808209

This PR changes the launch game command to use powershell, which prevents VS locking.
